### PR TITLE
ci: enforce PR guards

### DIFF
--- a/.github/workflows/guard-dev.yml
+++ b/.github/workflows/guard-dev.yml
@@ -1,0 +1,27 @@
+name: Guard dev PRs
+on:
+  pull_request:
+    branches: [ "dev" ]
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  signed-commits:
+    name: require-verified-commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all commits in PR are verified
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update -y >/dev/null 2>&1 || true
+          sudo apt-get install -y jq >/dev/null 2>&1 || true
+          commits_json=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/commits)
+          if echo "$commits_json" | jq 'map(.commit.verification.verified) | all' | grep -q true; then
+            echo "All commits in this PR are Verified ✅"
+          else
+            echo "❌ This PR contains unsigned/unverified commits. Please rebase/sign them." >&2
+            exit 1
+          fi

--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -1,0 +1,39 @@
+name: Guard main PRs
+on:
+  pull_request:
+    branches: [ "main" ]
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  only-from-dev:
+    name: require-dev-as-source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if head branch is not 'dev'
+        run: |
+          set -euo pipefail
+          if [ "${{ github.head_ref }}" != "dev" ]; then
+            echo "❌ Only PRs from 'dev' may be merged into 'main'." >&2
+            exit 1
+          fi
+  signed-commits:
+    name: require-verified-commits
+    runs-on: ubuntu-latest
+    needs: only-from-dev
+    steps:
+      - name: Check all commits in PR are verified
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update -y >/dev/null 2>&1 || true
+          sudo apt-get install -y jq >/dev/null 2>&1 || true
+          commits_json=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/commits)
+          if echo "$commits_json" | jq 'map(.commit.verification.verified) | all' | grep -q true; then
+            echo "All commits in this PR are Verified ✅"
+          else
+            echo "❌ This PR contains unsigned/unverified commits. Please rebase/sign them." >&2
+            exit 1
+          fi


### PR DESCRIPTION
Add guard workflows:
- dev: require verified commits in PR
- main: only allow PRs from dev + require verified commits