### PR TITLE
Release: local hooks + PR-only protections

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Block commits made directly on main
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+
+if [[ "$branch" == "main" ]]; then
+  echo "✋ Commit blocked: do not commit directly to 'main'."
+  echo "→ Create a branch:  git switch -c release/Mx   (or any feature branch)"
+  echo "→ Open a PR into main."
+  exit 1
+fi
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Block pushes that update the main branch
+# (pre-push receives lines: <local ref> <local sha> <remote ref> <remote sha>)
+protected="refs/heads/main"
+
+while read local_ref local_sha remote_ref remote_sha; do
+  if [[ "$remote_ref" == "$protected" ]]; then
+    echo "✋ Push blocked: direct updates to 'main' are not allowed."
+    echo "→ Push your branch and open a PR instead."
+    exit 1
+  fi
+done
+
+exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "jay-website",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "@handlebars/allow-prototype-access": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "build:html:local": "node --env-file=.env.local tools/build.mjs",
     "build": "npm run clean && npm run build:css && npm run build:html && npm run build:assets && npm run postcss:prod",
     "build:local": "npm run clean && npm run build:css && npm run build:html:local && npm run build:assets && npm run postcss:dev",
-    "dev": "npm run build:local && npx live-server dist --quiet"
+    "dev": "npm run build:local && npx live-server dist --quiet",
+    "setup:hooks": "git config core.hooksPath .githooks && [ -d .githooks ] && chmod +x .githooks/* || true",
+    "postinstall": "npm run setup:hooks"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds repo-managed Git hooks (pre-commit/pre-push) to protect main locally and auto-activates via postinstall. Matches server-side ruleset (PR-only).