### PR TITLE
build(assets): flatten assets copy (cp with trailing dot)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:css": "sass src/scss/main.scss dist/assets/css/main.css --style=compressed --no-source-map",
     "postcss:dev": "postcss dist/assets/css/main.css -o dist/assets/css/main.css --map inline",
     "postcss:prod": "postcss dist/assets/css/main.css -o dist/assets/css/main.css --no-map",
-    "build:assets": "cp -R src/assets dist/assets",
+    "build:assets": "mkdir -p dist/assets && cp -R src/assets/. dist/assets/",
     "//": "HTML builds: CI uses build:html (no env-file), local uses build:html:local (reads .env.local)",
     "build:html": "node tools/build.mjs",
     "build:html:local": "node --env-file=.env.local tools/build.mjs",


### PR DESCRIPTION
Use cp -R src/assets/. dist/assets/ so contents land directly in dist/assets and dotfiles (e.g. .nojekyll) are included.
