### PR TITLE
M02/#9 — Focus states + reduced-motion utilities

### DIFF
--- a/src/scss/abstracts/_functions.scss
+++ b/src/scss/abstracts/_functions.scss
@@ -1,3 +1,42 @@
 /* abstracts/_functions.scss
-   Sass functions (e.g., color contrast helpers) — to be added in Issue #8.
+   Small helpers to read token maps safely (no CSS output).
+   - space($key)          → spacing scale lookup
+   - type-step($step, k)  → "min" or "max" size for a type scale step
+   - bp($name)            → breakpoint value (min-width)
 */
+@use "sass:map";
+@use "sass:meta";
+@use "variables" as v;
+
+/* Spacing lookup: e.g., space(sm) → 0.75rem */
+@function space($key) {
+   @if (map.has-key(v.$space, $key)) {
+      @return map.get(v.$space, $key);
+   }
+
+   @error "Unknown spacing key `#{$key}`. Valid: #{map.keys(v.$space)}";
+}
+
+/* Type scale step lookup: type-step(3, min|max) */
+@function type-step($step, $which: min) {
+   @if (map.has-key(v.$type-scale, $step)) {
+      $pair: map.get(v.$type-scale, $step);
+
+      @if (map.has-key($pair, $which)) {
+         @return map.get($pair, $which);
+      }
+
+      @error "type-step(#{inspect($step)}, #{inspect($which)}): use `min` or `max`.";
+   }
+
+   @error "Unknown type step `#{$step}`. Valid: #{map.keys(v.$type-scale)}";
+}
+
+/* Breakpoint lookup: bp(sm|md|lg) returns rem value */
+@function bp($name) {
+   @if (map.has-key(v.$breakpoints, $name)) {
+      @return map.get(v.$breakpoints, $name);
+   }
+
+   @error "Unknown breakpoint `#{$name}`. Valid: #{map.keys(v.$breakpoints)}";
+}

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -1,3 +1,62 @@
 /* abstracts/_mixins.scss
-   Reusable mixins (e.g., fluid type, media queries) — to be added in Issue #8.
+   Reusable mixins. These DO NOT emit CSS by themselves; they’re used by other layers.
+
+   Included:
+   - mq($from)                     → @media (min-width: …) wrapper (mobile-first)
+   - fluid-type($step, $lh?, $w?)  → font-size: clamp(min, calc(...), max) from type scale
+   - prefers-reduced-motion        → wrap motion-heavy rules for users who prefer less motion
+   - focus-ring(...)               → consistent visible focus outline using tokens
 */
+@use "sass:math";
+@use "variables" as v;
+@use "functions" as f;
+
+/* Mobile-first media query helper */
+@mixin mq($from) {
+   @media (min-width: f.bp($from)) {
+      @content;
+   }
+}
+
+/* Fluid type from $type-scale at a named step.
+   Example: @include fluid-type(3, v.$line-tight, v.$weight-semibold);
+   MDN clamp(): https://developer.mozilla.org/en-US/docs/Web/CSS/clamp
+*/
+@mixin fluid-type($step, $line-height: null, $weight: null) {
+   $min: f.type-step($step, min);
+   $max: f.type-step($step, max);
+
+   /* Build a linear scaling between $fluid-min-vw and $fluid-max-vw */
+   $vw-range: v.$fluid-max-vw - v.$fluid-min-vw;
+   $size-diff: $max - $min;
+
+   font-size: clamp(#{$min},
+      calc(#{$min} + #{$size-diff} * ((100vw - #{v.$fluid-min-vw}) / #{$vw-range})),
+      #{$max});
+
+   @if $line-height !=null {
+      line-height: $line-height;
+   }
+
+   @if $weight !=null {
+      font-weight: $weight;
+   }
+}
+
+/* Respect users who prefer reduced motion (utilities will use this later) */
+@mixin prefers-reduced-motion {
+   @media (prefers-reduced-motion: reduce) {
+      @content;
+   }
+
+   /* MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion */
+}
+
+/* Visible focus ring (Issue #9 will add utilities; this mixin is ready now) */
+@mixin focus-ring($color: v.$focus-ring-color,
+   $width: v.$focus-outline-width,
+   $offset: v.$focus-outline-offset) {
+   outline: $width solid $color;
+   outline-offset: $offset;
+   /* MDN outline/offset: https://developer.mozilla.org/en-US/docs/Web/CSS/outline */
+}

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -1,9 +1,17 @@
 /* base/_base.scss
-   Project-wide element styles (html, body, headings, images), defaults.
-   We’ll hook real styles after tokens exist (Issue #8).
-*/
+   Minimal, accessible defaults to prove tokens + mixins are wired.
+   (Full component/page styling comes later.)
 
-/* Example safe default (outputs minimal CSS, no tokens yet): */
+   Uses:
+   - variables (tokens: colors, fonts, spacing)
+   - mixins.fluid-type for headings
+*/
+@use "../abstracts/variables" as v;
+@use "../abstracts/mixins" as m;
+@use "../abstracts/functions" as f;
+
+/* Global box model & image handling already present in your reset/base earlier;
+   we keep them here to ensure sensible defaults. */
 *,
 *::before,
 *::after {
@@ -14,7 +22,53 @@ html {
   -webkit-text-size-adjust: 100%;
 }
 
+/* Base document */
+html {
+  font-size: v.$font-size-root;
+}
+
+/* usually 16px → 100% */
+body {
+  margin: 0;
+  font-family: v.$font-sans;
+  color: v.$color-text;
+  background-color: v.$color-bg;
+  line-height: v.$line-normal;
+  /* MDN font-family: https://developer.mozilla.org/en-US/docs/Web/CSS/font-family */
+}
+
+/* Links */
+a {
+  color: v.$link-color;
+  text-decoration: underline;
+}
+
+a:hover {
+  color: v.$link-color-hover;
+}
+
+/* Fluid headings (tiny sample to demonstrate tokens working) */
+h1 {
+  @include m.fluid-type(5, v.$line-tight, v.$weight-bold);
+}
+
+h2 {
+  @include m.fluid-type(4, v.$line-tight, v.$weight-semibold);
+}
+
+h3 {
+  @include m.fluid-type(3, v.$line-tight, v.$weight-semibold);
+}
+
+/* Images remain responsive; keep intrinsic aspect to avoid CLS (see brief). */
 img {
   max-width: 100%;
   height: auto;
+}
+
+/* MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/max-width */
+
+/* Basic flow rhythm for text (kept subtle) */
+p {
+  margin-block: 0 f.space(md);
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -9,12 +9,11 @@
    6) utilities   – helpers and one-off utility classes
 
    Notes:
-   - Real tokens (colors/spacing/type/breakpoints) arrive in Issue #8.
-   - Focus + reduced-motion utilities arrive in Issue #9.
-   - Using Sass modules (@use) keeps things tidy and avoids @import (deprecated).
+   - Tokens were added in Issue #8.
+   - Focus + reduced-motion utilities are Issue #9 (this step).
 */
 
-/* 1) ABSTRACTS (no CSS output expected yet) */
+/* 1) ABSTRACTS (no CSS output expected) */
 @use "abstracts/functions";
 @use "abstracts/mixins";
 @use "abstracts/variables";
@@ -38,3 +37,5 @@
 /* 6) UTILITIES (helpers & a11y utilities) */
 @use "utilities/visually-hidden";
 @use "utilities/helpers";
+@use "utilities/focus";
+@use "utilities/motion";

--- a/src/scss/utilities/_focus.scss
+++ b/src/scss/utilities/_focus.scss
@@ -1,0 +1,27 @@
+/* utilities/_focus.scss
+   Visible, consistent focus styles using tokens + mixin.
+   - Applies a strong outline to any element when it matches :focus-visible
+   - Adds a non-colour-only cue for links (thicker underline) to aid contrast
+   References:
+   - :focus-visible: https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
+*/
+@use "../abstracts/variables" as v;
+@use "../abstracts/mixins" as m;
+
+/* Global focus ring — keyboard users see this, mouse users typically won’t */
+:focus-visible {
+  @include m.focus-ring(v.$focus-ring-color, v.$focus-outline-width, v.$focus-outline-offset);
+}
+
+/* Extra affordance for links: reinforce with an underline change, not just color */
+a:focus-visible {
+  text-decoration: underline;
+  text-decoration-thickness: 0.14em;
+  /* ~2px at common sizes */
+  text-underline-offset: 0.15em;
+}
+
+/* Opt-in utility if you need to force a focus ring on custom components */
+.u-focus-ring {
+  @include m.focus-ring(v.$focus-ring-color, v.$focus-outline-width, v.$focus-outline-offset);
+}

--- a/src/scss/utilities/_motion.scss
+++ b/src/scss/utilities/_motion.scss
@@ -1,0 +1,28 @@
+/* utilities/_motion.scss
+   Respect users who prefer reduced motion.
+   - Globally minimizes animation/transition durations when the user opts out.
+   - You can still author animations in components; users with "reduce" won’t get them.
+   Reference:
+   - prefers-reduced-motion: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
+*/
+@use "../abstracts/mixins" as m;
+
+/* Global guard: drastically reduce motion for users who selected "reduce" */
+@include m.prefers-reduced-motion {
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Optional helper class: only run motion when user has no preference.
+   Usage example in a component:
+     @media (prefers-reduced-motion: no-preference) {
+       .fade-in { transition: opacity 150ms; }
+     }
+   (We expose this pattern here as a comment, to keep utilities minimal.) */


### PR DESCRIPTION
## Summary
Add accessible focus styles and reduced-motion guard. Uses the tokens + mixins introduced in #8.

## Changes
- `utilities/_focus.scss`: global :focus-visible outline via focus-ring mixin; stronger underline for links; opt-in `.u-focus-ring`.
- `utilities/_motion.scss`: global prefers-reduced-motion guard to minimize animations/transitions.
- `main.scss`: wire new utilities.

## Ref
Ref #9

## Closes

