### PR TITLE
M02 — SCSS architecture, tokens, and a11y utilities

### DIFF
--- a/src/scss/abstracts/_functions.scss
+++ b/src/scss/abstracts/_functions.scss
@@ -1,0 +1,3 @@
+/* abstracts/_functions.scss
+   Sass functions (e.g., color contrast helpers) — to be added in Issue #8.
+*/

--- a/src/scss/abstracts/_functions.scss
+++ b/src/scss/abstracts/_functions.scss
@@ -1,3 +1,42 @@
 /* abstracts/_functions.scss
-   Sass functions (e.g., color contrast helpers) — to be added in Issue #8.
+   Small helpers to read token maps safely (no CSS output).
+   - space($key)          → spacing scale lookup
+   - type-step($step, k)  → "min" or "max" size for a type scale step
+   - bp($name)            → breakpoint value (min-width)
 */
+@use "sass:map";
+@use "sass:meta";
+@use "variables" as v;
+
+/* Spacing lookup: e.g., space(sm) → 0.75rem */
+@function space($key) {
+   @if (map.has-key(v.$space, $key)) {
+      @return map.get(v.$space, $key);
+   }
+
+   @error "Unknown spacing key `#{$key}`. Valid: #{map.keys(v.$space)}";
+}
+
+/* Type scale step lookup: type-step(3, min|max) */
+@function type-step($step, $which: min) {
+   @if (map.has-key(v.$type-scale, $step)) {
+      $pair: map.get(v.$type-scale, $step);
+
+      @if (map.has-key($pair, $which)) {
+         @return map.get($pair, $which);
+      }
+
+      @error "type-step(#{inspect($step)}, #{inspect($which)}): use `min` or `max`.";
+   }
+
+   @error "Unknown type step `#{$step}`. Valid: #{map.keys(v.$type-scale)}";
+}
+
+/* Breakpoint lookup: bp(sm|md|lg) returns rem value */
+@function bp($name) {
+   @if (map.has-key(v.$breakpoints, $name)) {
+      @return map.get(v.$breakpoints, $name);
+   }
+
+   @error "Unknown breakpoint `#{$name}`. Valid: #{map.keys(v.$breakpoints)}";
+}

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -1,3 +1,62 @@
 /* abstracts/_mixins.scss
-   Reusable mixins (e.g., fluid type, media queries) — to be added in Issue #8.
+   Reusable mixins. These DO NOT emit CSS by themselves; they’re used by other layers.
+
+   Included:
+   - mq($from)                     → @media (min-width: …) wrapper (mobile-first)
+   - fluid-type($step, $lh?, $w?)  → font-size: clamp(min, calc(...), max) from type scale
+   - prefers-reduced-motion        → wrap motion-heavy rules for users who prefer less motion
+   - focus-ring(...)               → consistent visible focus outline using tokens
 */
+@use "sass:math";
+@use "variables" as v;
+@use "functions" as f;
+
+/* Mobile-first media query helper */
+@mixin mq($from) {
+   @media (min-width: f.bp($from)) {
+      @content;
+   }
+}
+
+/* Fluid type from $type-scale at a named step.
+   Example: @include fluid-type(3, v.$line-tight, v.$weight-semibold);
+   MDN clamp(): https://developer.mozilla.org/en-US/docs/Web/CSS/clamp
+*/
+@mixin fluid-type($step, $line-height: null, $weight: null) {
+   $min: f.type-step($step, min);
+   $max: f.type-step($step, max);
+
+   /* Build a linear scaling between $fluid-min-vw and $fluid-max-vw */
+   $vw-range: v.$fluid-max-vw - v.$fluid-min-vw;
+   $size-diff: $max - $min;
+
+   font-size: clamp(#{$min},
+      calc(#{$min} + #{$size-diff} * ((100vw - #{v.$fluid-min-vw}) / #{$vw-range})),
+      #{$max});
+
+   @if $line-height !=null {
+      line-height: $line-height;
+   }
+
+   @if $weight !=null {
+      font-weight: $weight;
+   }
+}
+
+/* Respect users who prefer reduced motion (utilities will use this later) */
+@mixin prefers-reduced-motion {
+   @media (prefers-reduced-motion: reduce) {
+      @content;
+   }
+
+   /* MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion */
+}
+
+/* Visible focus ring (Issue #9 will add utilities; this mixin is ready now) */
+@mixin focus-ring($color: v.$focus-ring-color,
+   $width: v.$focus-outline-width,
+   $offset: v.$focus-outline-offset) {
+   outline: $width solid $color;
+   outline-offset: $offset;
+   /* MDN outline/offset: https://developer.mozilla.org/en-US/docs/Web/CSS/outline */
+}

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -1,0 +1,3 @@
+/* abstracts/_mixins.scss
+   Reusable mixins (e.g., fluid type, media queries) — to be added in Issue #8.
+*/

--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -1,6 +1,209 @@
 /* abstracts/_variables.scss
-   Design tokens live here (colors, spacing, typography, breakpoints).
-   NOTE: Leave real values for Issue #8 (Design tokens).
-   Keep variables behind !default so downstream themes can override.
+   Design tokens: colors, spacing, typography, breakpoints, motion, focus.
+   - Tokens only; NO CSS output here.
+   - Keep values behind !default so themes/overrides can replace them.
+   - Colors selected to reach AA contrast in common pairings noted below.
+   - Mobile-first: breakpoints are min-width in rem units.
+
+   References:
+   - AA contrast targets guide our color choices (normal text ≥ 4.5:1).
+   - Breakpoints align with wireframe notes (0, 640px, 960px, 1280px).
 */
-$todo-token-example: null !default; // placeholder; will be removed in #8
+
+/* --------------------------------------------------------------------------------
+   COLOR PALETTE (foundations)
+-------------------------------------------------------------------------------- */
+
+$white: #ffffff !default;
+$black: #000000 !default;
+
+/* Neutral / Slate scale */
+$gray-50: #f8fafc !default;
+/* bg-subtle on white UIs */
+$gray-100: #f1f5f9 !default;
+$gray-200: #e2e8f0 !default;
+/* borders on light */
+$gray-700: #334155 !default;
+/* muted text on white (AA vs white) */
+$gray-900: #0f172a !default;
+/* primary body text on white (AA vs white) */
+
+/* Brand + accents */
+$brand-600: #2563eb !default;
+/* links on white (AA vs white) + brand surfaces with $on-brand */
+$brand-700: #1d4ed8 !default;
+/* hover/active, darker brand */
+
+$accent-600: #9333ea !default;
+/* optional secondary accent */
+
+/* Semantic hues chosen to meet AA when used as text on white,
+   and to permit white text on their solid backgrounds. */
+$success-700: #047857 !default;
+/* AA vs white; white-on-success also AA */
+$danger-600: #dc2626 !default;
+/* AA vs white; white-on-danger also AA */
+$warning-700: #b45309 !default;
+/* AA vs white; white-on-warning also AA */
+$info-700: #0369a1 !default;
+/* AA vs white; white-on-info also AA */
+
+/* --------------------------------------------------------------------------------
+   COLOR ROLES (use these across components)
+-------------------------------------------------------------------------------- */
+
+/* Light theme defaults */
+$color-bg: $white !default;
+/* page background */
+$color-surface: $white !default;
+/* card/panel background */
+$color-text: $gray-900 !default;
+/* primary text on $color-bg */
+$color-muted: $gray-700 !default;
+/* secondary text on $color-bg */
+$color-border: $gray-200 !default;
+/* dividers/borders */
+
+$color-brand: $brand-600 !default;
+$color-brand-strong: $brand-700 !default;
+$on-brand: $white !default;
+/* text/icon color placed on brand surfaces */
+
+$link-color: $color-brand !default;
+/* AA vs white bg */
+$link-color-hover: $color-brand-strong !default;
+/* darker on hover */
+
+/* Semantic role colors (as text on white) */
+$color-success: $success-700 !default;
+$color-danger: $danger-600 !default;
+$color-warning: $warning-700 !default;
+$color-info: $info-700 !default;
+
+/* Text on solid semantic backgrounds */
+$on-success: $white !default;
+$on-danger: $white !default;
+$on-warning: $white !default;
+$on-info: $white !default;
+
+/* --------------------------------------------------------------------------------
+   TYPOGRAPHY
+-------------------------------------------------------------------------------- */
+
+/* Font stacks (system-first; swap to custom fonts later if added in /assets/fonts) */
+$font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+   "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji", sans-serif !default;
+
+$font-serif: Georgia, Cambria, "Times New Roman", Times, serif !default;
+
+$font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+   "Liberation Mono", "Courier New", monospace !default;
+
+/* Base metrics */
+$font-size-root: 100% !default;
+/* 16px by default; set on html later in base */
+$line-tight: 1.25 !default;
+$line-normal: 1.5 !default;
+$line-loose: 1.7 !default;
+
+$weight-regular: 400 !default;
+$weight-medium: 500 !default;
+$weight-semibold: 600 !default;
+$weight-bold: 700 !default;
+
+/* Type scale (for fluid sizing in mixins later).
+   Each step provides a min/max that a fluid-type mixin can clamp() between
+   across a viewport range (see $fluid-min-vw / $fluid-max-vw below). */
+$type-scale: (
+   -2: (min: 0.75rem, max: 0.875rem),
+   /* captions, helper text */
+   -1: (min: 0.875rem, max: 1rem),
+   /* small text */
+   0: (min: 1rem, max: 1.125rem),
+   /* body */
+   1: (min: 1.125rem, max: 1.25rem),
+   /* lead / h6 */
+   2: (min: 1.25rem, max: 1.5rem),
+   /* h5 */
+   3: (min: 1.5rem, max: 1.875rem),
+   /* h4 */
+   4: (min: 1.875rem, max: 2.25rem),
+   /* h3 */
+   5: (min: 2.25rem, max: 3rem)
+   /* h2/h1 */
+   ) !default;
+
+/* --------------------------------------------------------------------------------
+   SPACING (4pt system, expressed in rem)
+-------------------------------------------------------------------------------- */
+
+$space-3xs: 0.125rem !default;
+/* 2px  */
+$space-2xs: 0.25rem !default;
+/* 4px  */
+$space-xs: 0.5rem !default;
+/* 8px  */
+$space-sm: 0.75rem !default;
+/* 12px */
+$space-md: 1rem !default;
+/* 16px */
+$space-lg: 1.5rem !default;
+/* 24px */
+$space-xl: 2rem !default;
+/* 32px */
+$space-2xl: 3rem !default;
+/* 48px */
+$space-3xl: 4rem !default;
+/* 64px */
+$space-4xl: 6rem !default;
+/* 96px */
+
+/* Map form for future helpers/mixins (no output here) */
+$space: (
+   3xs: $space-3xs,
+   2xs: $space-2xs,
+   xs: $space-xs,
+   sm: $space-sm,
+   md: $space-md,
+   lg: $space-lg,
+   xl: $space-xl,
+   2xl: $space-2xl,
+   3xl: $space-3xl,
+   4xl: $space-4xl) !default;
+
+/* --------------------------------------------------------------------------------
+   LAYOUT / BREAKPOINTS (mobile-first, min-width in rem)
+-------------------------------------------------------------------------------- */
+
+$container-max: 72rem !default;
+/* ~1152px; wireframe suggests ~72rem containers */
+
+$breakpoints: (
+   sm: 40rem,
+   /* 640px */
+   md: 60rem,
+   /* 960px */
+   lg: 80rem
+   /* 1280px */
+   ) !default;
+
+/* Fluid type viewport range (used by mixins in the next step) */
+$fluid-min-vw: 20rem !default;
+/* 320px */
+$fluid-max-vw: 80rem !default;
+/* 1280px */
+
+/* --------------------------------------------------------------------------------
+   FOCUS & MOTION TOKENS (consumed by utilities in later issues)
+-------------------------------------------------------------------------------- */
+
+$focus-outline-width: 3px !default;
+/* wireframe: 2–3px visible focus */
+$focus-outline-offset: 3px !default;
+$focus-ring-color: currentColor !default;
+/* non-color-only cues come later */
+
+$motion-duration-1: 150ms !default;
+$motion-duration-2: 250ms !default;
+$motion-ease-standard: cubic-bezier(.2, .8, .2, 1) !default;
+/* prefers-reduced-motion handling will be added in utilities and mixins later */

--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -1,0 +1,6 @@
+/* abstracts/_variables.scss
+   Design tokens live here (colors, spacing, typography, breakpoints).
+   NOTE: Leave real values for Issue #8 (Design tokens).
+   Keep variables behind !default so downstream themes can override.
+*/
+$todo-token-example: null !default; // placeholder; will be removed in #8

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -1,9 +1,17 @@
 /* base/_base.scss
-   Project-wide element styles (html, body, headings, images), defaults.
-   We’ll hook real styles after tokens exist (Issue #8).
-*/
+   Minimal, accessible defaults to prove tokens + mixins are wired.
+   (Full component/page styling comes later.)
 
-/* Example safe default (outputs minimal CSS, no tokens yet): */
+   Uses:
+   - variables (tokens: colors, fonts, spacing)
+   - mixins.fluid-type for headings
+*/
+@use "../abstracts/variables" as v;
+@use "../abstracts/mixins" as m;
+@use "../abstracts/functions" as f;
+
+/* Global box model & image handling already present in your reset/base earlier;
+   we keep them here to ensure sensible defaults. */
 *,
 *::before,
 *::after {
@@ -14,7 +22,53 @@ html {
   -webkit-text-size-adjust: 100%;
 }
 
+/* Base document */
+html {
+  font-size: v.$font-size-root;
+}
+
+/* usually 16px → 100% */
+body {
+  margin: 0;
+  font-family: v.$font-sans;
+  color: v.$color-text;
+  background-color: v.$color-bg;
+  line-height: v.$line-normal;
+  /* MDN font-family: https://developer.mozilla.org/en-US/docs/Web/CSS/font-family */
+}
+
+/* Links */
+a {
+  color: v.$link-color;
+  text-decoration: underline;
+}
+
+a:hover {
+  color: v.$link-color-hover;
+}
+
+/* Fluid headings (tiny sample to demonstrate tokens working) */
+h1 {
+  @include m.fluid-type(5, v.$line-tight, v.$weight-bold);
+}
+
+h2 {
+  @include m.fluid-type(4, v.$line-tight, v.$weight-semibold);
+}
+
+h3 {
+  @include m.fluid-type(3, v.$line-tight, v.$weight-semibold);
+}
+
+/* Images remain responsive; keep intrinsic aspect to avoid CLS (see brief). */
 img {
   max-width: 100%;
   height: auto;
+}
+
+/* MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/max-width */
+
+/* Basic flow rhythm for text (kept subtle) */
+p {
+  margin-block: 0 f.space(md);
 }

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -1,0 +1,20 @@
+/* base/_base.scss
+   Project-wide element styles (html, body, headings, images), defaults.
+   We’ll hook real styles after tokens exist (Issue #8).
+*/
+
+/* Example safe default (outputs minimal CSS, no tokens yet): */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}

--- a/src/scss/base/_reset.scss
+++ b/src/scss/base/_reset.scss
@@ -1,0 +1,5 @@
+/* base/_reset.scss
+   Choice of reset/normalize goes here. For now, we keep this empty and
+   add a lightweight reset in a later pass to avoid scope creep.
+   See: https://developer.mozilla.org/docs/Web/CSS/Cascade
+*/

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -1,0 +1,4 @@
+/* components/_buttons.scss
+   Button variants (primary/secondary), sizes, and states.
+   Will use tokens from abstracts in Issue #8.
+*/

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -1,0 +1,4 @@
+/* components/_cards.scss
+   Card container, header, body, media ratio helpers for project cards.
+   Real styles to come later; scaffold only.
+*/

--- a/src/scss/components/_nav.scss
+++ b/src/scss/components/_nav.scss
@@ -1,0 +1,4 @@
+/* components/_nav.scss
+   Site nav styling (header nav list, active link state).
+   Actual rules will use tokens (Issue #8).
+*/

--- a/src/scss/layout/_grid.scss
+++ b/src/scss/layout/_grid.scss
@@ -1,0 +1,4 @@
+/* layout/_grid.scss
+   Container widths, columns, and gaps (mobile-first).
+   Will pick up spacing/type scales from tokens (Issue #8).
+*/

--- a/src/scss/layout/_layout.scss
+++ b/src/scss/layout/_layout.scss
@@ -1,0 +1,4 @@
+/* layout/_layout.scss
+   Shared page structure: header, main, footer wrappers, section spacing.
+   Keep minimal until tokens exist.
+*/

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -9,12 +9,11 @@
    6) utilities   – helpers and one-off utility classes
 
    Notes:
-   - Real tokens (colors/spacing/type/breakpoints) arrive in Issue #8.
-   - Focus + reduced-motion utilities arrive in Issue #9.
-   - Using Sass modules (@use) keeps things tidy and avoids @import (deprecated).
+   - Tokens were added in Issue #8.
+   - Focus + reduced-motion utilities are Issue #9 (this step).
 */
 
-/* 1) ABSTRACTS (no CSS output expected yet) */
+/* 1) ABSTRACTS (no CSS output expected) */
 @use "abstracts/functions";
 @use "abstracts/mixins";
 @use "abstracts/variables";
@@ -38,3 +37,5 @@
 /* 6) UTILITIES (helpers & a11y utilities) */
 @use "utilities/visually-hidden";
 @use "utilities/helpers";
+@use "utilities/focus";
+@use "utilities/motion";

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,42 +1,40 @@
-/* Minimal AA-friendly baseline; mobile-first */
-:focus-visible {
-  outline: 2px solid currentColor;
-  outline-offset: 3px;
-}
+/* src/scss/main.scss
+   Entry point for the 7–1 architecture.
+   Load order matters:
+   1) abstracts   – tokens, functions, mixins (no CSS output ideally)
+   2) base        – resets and element defaults
+   3) layout      – structural layout primitives (containers, grid)
+   4) components  – discrete UI chunks (buttons, cards, nav)
+   5) sections    – page/section-specific styles
+   6) utilities   – helpers and one-off utility classes
 
-@media (prefers-reduced-motion: reduce) {
-  * {
-    animation-duration: .001ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: .001ms !important;
-  }
-}
+   Notes:
+   - Real tokens (colors/spacing/type/breakpoints) arrive in Issue #8.
+   - Focus + reduced-motion utilities arrive in Issue #9.
+   - Using Sass modules (@use) keeps things tidy and avoids @import (deprecated).
+*/
 
-:root {
-  --space: 0.75rem;
-}
+/* 1) ABSTRACTS (no CSS output expected yet) */
+@use "abstracts/functions";
+@use "abstracts/mixins";
+@use "abstracts/variables";
 
-body {
-  font-family: system-ui, sans-serif;
-  line-height: 1.6;
-  margin: 0;
-  padding: 2rem;
-}
+/* 2) BASE (global element defaults / light reset) */
+@use "base/reset";
+@use "base/base";
 
-.stack>*+* {
-  margin-top: var(--space);
-}
+/* 3) LAYOUT (page structure, containers, grids) */
+@use "layout/grid";
+@use "layout/layout";
 
-.skip-link {
-  position: absolute;
-  left: -9999px;
-  top: auto;
-}
+/* 4) COMPONENTS (reusable UI) */
+@use "components/buttons";
+@use "components/cards";
+@use "components/nav";
 
-.skip-link:focus {
-  left: 1rem;
-  top: 1rem;
-  background: #fff;
-  padding: .5rem .75rem;
-  border: 1px solid;
-}
+/* 5) SECTIONS (page-level rules) */
+@use "sections/home";
+
+/* 6) UTILITIES (helpers & a11y utilities) */
+@use "utilities/visually-hidden";
+@use "utilities/helpers";

--- a/src/scss/sections/_home.scss
+++ b/src/scss/sections/_home.scss
@@ -1,0 +1,4 @@
+/* sections/_home.scss
+   Page/section-level styles used on Home (hero, featured projects, etc.).
+   Detailed rules later; placeholder for now.
+*/

--- a/src/scss/utilities/_focus.scss
+++ b/src/scss/utilities/_focus.scss
@@ -1,0 +1,27 @@
+/* utilities/_focus.scss
+   Visible, consistent focus styles using tokens + mixin.
+   - Applies a strong outline to any element when it matches :focus-visible
+   - Adds a non-colour-only cue for links (thicker underline) to aid contrast
+   References:
+   - :focus-visible: https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
+*/
+@use "../abstracts/variables" as v;
+@use "../abstracts/mixins" as m;
+
+/* Global focus ring — keyboard users see this, mouse users typically won’t */
+:focus-visible {
+  @include m.focus-ring(v.$focus-ring-color, v.$focus-outline-width, v.$focus-outline-offset);
+}
+
+/* Extra affordance for links: reinforce with an underline change, not just color */
+a:focus-visible {
+  text-decoration: underline;
+  text-decoration-thickness: 0.14em;
+  /* ~2px at common sizes */
+  text-underline-offset: 0.15em;
+}
+
+/* Opt-in utility if you need to force a focus ring on custom components */
+.u-focus-ring {
+  @include m.focus-ring(v.$focus-ring-color, v.$focus-outline-width, v.$focus-outline-offset);
+}

--- a/src/scss/utilities/_helpers.scss
+++ b/src/scss/utilities/_helpers.scss
@@ -1,0 +1,4 @@
+/* utilities/_helpers.scss
+   Small single-purpose helpers (e.g., .stack, .flow, text utilities).
+   Will be filled as needed later.
+*/

--- a/src/scss/utilities/_motion.scss
+++ b/src/scss/utilities/_motion.scss
@@ -1,0 +1,28 @@
+/* utilities/_motion.scss
+   Respect users who prefer reduced motion.
+   - Globally minimizes animation/transition durations when the user opts out.
+   - You can still author animations in components; users with "reduce" won’t get them.
+   Reference:
+   - prefers-reduced-motion: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
+*/
+@use "../abstracts/mixins" as m;
+
+/* Global guard: drastically reduce motion for users who selected "reduce" */
+@include m.prefers-reduced-motion {
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Optional helper class: only run motion when user has no preference.
+   Usage example in a component:
+     @media (prefers-reduced-motion: no-preference) {
+       .fade-in { transition: opacity 150ms; }
+     }
+   (We expose this pattern here as a comment, to keep utilities minimal.) */

--- a/src/scss/utilities/_visually-hidden.scss
+++ b/src/scss/utilities/_visually-hidden.scss
@@ -1,0 +1,16 @@
+/* utilities/_visually-hidden.scss
+   A standard “visually hidden but screen-reader accessible” helper.
+   MDN discussion: https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Attributes/aria-hidden#hiding_content_visually
+*/
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}


### PR DESCRIPTION
## Summary
Milestone M02 delivers the SCSS 7–1 architecture, design tokens (colors, spacing, typography, breakpoints), and a11y utilities for visible focus and reduced motion. Mobile-first, WCAG AA-minded, and ready for future components/sections.

## Changes
- #7: Scaffold 7–1 folders (abstracts, base, components, layout, sections, utilities) and wire `src/scss/main.scss`.
- #8: Add tokens in `abstracts/_variables.scss` (color roles, spacing scale, type stacks & scale, breakpoints, motion/focus tokens). Add helpers in `abstracts/_functions.scss` and `abstracts/_mixins.scss` (mq, fluid-type via `clamp()`, focus-ring, prefers-reduced-motion). Minimal base typography using tokens.
- #9: Add `utilities/_focus.scss` (`:focus-visible` outline + stronger underline for links) and `utilities/_motion.scss` (global reduced-motion guard). Wire utilities in `main.scss`.

## Verification
- Local build: `npm run dev` (or `npm run build`).
- CSS contains `clamp()` for fluid headings and `:focus-visible` + `prefers-reduced-motion` rules.
- Manual check: headings scale fluidly; tab focus shows a clear outline; motion reduced when OS pref is set.

## Ref
Ref #7  
Ref #8  
Ref #9

## Closes
Closes #7  
Closes #8  
Closes #9

