### PR TITLE
feat(about,projects): templates + CSS (Ref #11)

### DIFF
--- a/src/data/site.json
+++ b/src/data/site.json
@@ -12,7 +12,11 @@
       },
       {
         "label": "Projects",
-        "href": "#projects"
+        "href": "/projects.html"
+      },
+      {
+        "label": "About",
+        "href": "/about.html"
       },
       {
         "label": "Contact",
@@ -31,6 +35,19 @@
           "label": "X"
         }
       ]
-    }
+    },
+    "about": {
+      "bio": [
+        "I'm a hands-on designer-developer focused on accessible, mobile-first web experiences.",
+        "This site is being built in the open: lightweight templates, SCSS in a 7-1 architecture, and CI/CD via GitHub Pages."
+      ],
+      "portrait": {
+        "src": "",
+        "alt": "Portrait of Jay Telford",
+        "width": 0,
+        "height": 0
+      }
+    },
+    "projects": []
   }
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -33,6 +33,8 @@
 
 /* 5) SECTIONS (page-level rules) */
 @use "sections/home";
+@use "sections/about";
+@use "sections/projects";
 
 /* 6) UTILITIES (helpers & a11y utilities) */
 @use "utilities/visually-hidden";

--- a/src/scss/sections/_about.scss
+++ b/src/scss/sections/_about.scss
@@ -1,0 +1,48 @@
+/* sections/_about.scss
+   About page styles (mobile-first, no motion).
+   - Comfortable vertical spacing
+   - Readable measure for bio paragraphs
+   - Portrait scales down fluidly while honoring intrinsic dimensions
+*/
+
+.about {
+  padding-block: 1.5rem;
+  /* top/bottom */
+}
+
+.about p {
+  max-width: 65ch;
+  /* readable line length */
+  margin: 0;
+  /* let container spacing control rhythm */
+}
+
+.about__figure {
+  margin: 0 0 1rem 0;
+  /* space below image on small screens */
+  max-width: 16rem;
+  /* keep portraits modest on mobile */
+}
+
+.about__figure img {
+  display: block;
+  max-width: 100%;
+  /* fluid downscale, never overflow */
+  height: auto;
+  /* preserve aspect ratio (honors width/height attrs) */
+  border-radius: 0.5rem;
+}
+
+/* Slightly roomier on wider screens, no layout shifts */
+@media (min-width: 48rem) {
+
+  /* ~768px */
+  .about {
+    padding-block: 2rem;
+  }
+
+  .about__figure {
+    margin-bottom: 1.25rem;
+    max-width: 20rem;
+  }
+}

--- a/src/scss/sections/_projects.scss
+++ b/src/scss/sections/_projects.scss
@@ -1,0 +1,15 @@
+/* sections/_projects.scss
+   Projects index page styles (mobile-first).
+   Reuses .cards / .card from components.
+*/
+
+.projects {
+  padding-block: 1.5rem;
+}
+
+/* Optional: give the list a touch more breathing room on larger screens */
+@media (min-width: 48rem) {
+  .projects {
+    padding-block: 2rem;
+  }
+}

--- a/src/templates/about.hbs
+++ b/src/templates/about.hbs
@@ -1,0 +1,27 @@
+{{!-- src/templates/about.hbs --}}
+{{!-- About page: single H1, optional portrait, bio paragraphs --}}
+{{#> layouts/base page=(hash title="About" description=site.description path="/about.html")}}
+<section class="about stack" aria-labelledby="about-title">
+  <h1 id="about-title">About</h1>
+
+  {{!-- Optional portrait with explicit dimensions to avoid CLS --}}
+  {{#if site.about}}
+  {{#if site.about.portrait.src}}
+  <figure class="about__figure">
+    <img src="{{prefixBase site.about.portrait.src site.base}}" width="{{site.about.portrait.width}}"
+      height="{{site.about.portrait.height}}" alt="{{site.about.portrait.alt}}">
+  </figure>
+  {{/if}}
+
+  {{#if site.about.bio}}
+  {{#each site.about.bio}}
+  <p>{{this}}</p>
+  {{/each}}
+  {{else}}
+  <p>Bio coming soon.</p>
+  {{/if}}
+  {{else}}
+  <p>Bio coming soon.</p>
+  {{/if}}
+</section>
+{{/layouts/base}}

--- a/src/templates/projects.hbs
+++ b/src/templates/projects.hbs
@@ -1,0 +1,33 @@
+{{!-- src/templates/projects.hbs --}}
+{{!-- Projects index: single H1, list of cards if data exists --}}
+{{#> layouts/base page=(hash title="Projects" description=site.description path="/projects.html")}}
+<section class="projects stack" aria-labelledby="projects-title">
+  <h1 id="projects-title">Projects</h1>
+
+  {{#if site.projects}}
+  {{#if site.projects.length}}
+  <ul class="cards">
+    {{#each site.projects}}
+    <li class="card">
+      {{#if this.url}}
+      <a class="card__link" href="{{prefixBase this.url ../../site.base}}">
+        <h2 class="card__title">{{this.title}}</h2>
+        {{#if this.summary}}<p class="card__summary">{{this.summary}}</p>{{/if}}
+      </a>
+      {{else}}
+      <div class="card__body">
+        <h2 class="card__title">{{this.title}}</h2>
+        {{#if this.summary}}<p class="card__summary">{{this.summary}}</p>{{/if}}
+      </div>
+      {{/if}}
+    </li>
+    {{/each}}
+  </ul>
+  {{else}}
+  <p>No projects yet.</p>
+  {{/if}}
+  {{else}}
+  <p>No projects yet.</p>
+  {{/if}}
+</section>
+{{/layouts/base}}


### PR DESCRIPTION
## Summary
Adds semantic About and Projects pages plus minimal, mobile-first CSS. Reuses existing .cards component for Projects. About portrait is fluid and CLS-safe (honors intrinsic width/height).

## Changes
- NEW: src/templates/about.hbs
- NEW: src/templates/projects.hbs
- NEW: src/scss/sections/_about.scss
- NEW: src/scss/sections/_projects.scss
- UPDATE: src/scss/main.scss (add @use for sections/about and sections/projects)
- UPDATE: src/data/site.json (nav entries, about.bio/portrait, empty projects)

## How to Test
1) `npm run build` then open `dist/`.
2) Visit `/about.html` — one `<h1>About</h1>`, readable bio paragraphs, portrait only if `site.about.portrait.src` is set.
3) Visit `/projects.html` — shows “No projects yet.” until items are added to `site.projects`.
4) Keyboard: focus rings visible; skip link still works.

## References
Ref #11

