### PR TITLE
M03: Core Pages (Home, About, Projects, 404) + A11Y skip link

### DIFF
--- a/docs/deferred/98-pr-build-automerge.md
+++ b/docs/deferred/98-pr-build-automerge.md
@@ -1,0 +1,17 @@
+# Deferred: PR build check + auto-merge (Issue #98)
+
+**Status:** Deferred (no code added)  
+**Reason:** Not working on this right now; keeping a placeholder for future work.
+
+## What we intentionally did **not** do
+- No workflow files added to `.github/workflows/`
+- No repository settings changed
+- No `package.json` scripts altered
+
+## When we pick this back up
+1. Add `.github/workflows/pr-build.yml` to build PRs (Node 20, `npm ci`, `npm run build:local` → fallback `npm run build`).
+2. Target PRs into `ms/m03` and `main`.
+3. Optionally run ESLint/Prettier jobs if configs exist.
+4. Enable “Allow auto-merge” in repo settings and choose it per PR if desired.
+
+*This note exists only to record that Issue #98 is deliberately deferred.*

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -12,7 +12,11 @@
       },
       {
         "label": "Projects",
-        "href": "#projects"
+        "href": "/projects.html"
+      },
+      {
+        "label": "About",
+        "href": "/about.html"
       },
       {
         "label": "Contact",
@@ -31,6 +35,19 @@
           "label": "X"
         }
       ]
-    }
+    },
+    "about": {
+      "bio": [
+        "I'm a hands-on designer-developer focused on accessible, mobile-first web experiences.",
+        "This site is being built in the open: lightweight templates, SCSS in a 7-1 architecture, and CI/CD via GitHub Pages."
+      ],
+      "portrait": {
+        "src": "",
+        "alt": "Portrait of Jay Telford",
+        "width": 0,
+        "height": 0
+      }
+    },
+    "projects": []
   }
 }

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -1,4 +1,26 @@
 /* components/_buttons.scss
-   Button variants (primary/secondary), sizes, and states.
-   Will use tokens from abstracts in Issue #8.
+   Minimal, accessible button/link styling.
+   - No forced animations; visible focus.
 */
+
+.button {
+   display: inline-block;
+   padding: 0.625rem 0.875rem;
+   border: 2px solid currentColor;
+   border-radius: 0.375rem;
+   background: transparent;
+   color: inherit;
+   text-decoration: none;
+   font: inherit;
+   line-height: 1;
+   cursor: pointer;
+}
+
+.button:hover {
+   text-decoration: underline;
+}
+
+.button:focus-visible {
+   outline: 2px solid currentColor;
+   outline-offset: 3px;
+}

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -1,4 +1,71 @@
 /* components/_cards.scss
-   Card container, header, body, media ratio helpers for project cards.
-   Real styles to come later; scaffold only.
+   Project cards list and card styling (mobile-first).
+   Accessible focus styles; no forced motion.
+   MDN grid: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout
 */
+
+.cards {
+   display: grid;
+   gap: 1rem;
+   list-style: none;
+   padding: 0;
+   margin: 0;
+   grid-template-columns: 1fr;
+   /* mobile-first single column */
+}
+
+.card {
+   background: #ffffff;
+   border: 1px solid #e5e7eb;
+   /* light gray */
+   border-radius: 0.5rem;
+   padding: 1rem;
+}
+
+.card__link {
+   display: block;
+   text-decoration: none;
+   color: inherit;
+}
+
+.card__title {
+   margin: 0 0 0.25rem 0;
+   font-size: 1.125rem;
+   /* ~18px */
+   line-height: 1.2;
+}
+
+.card__summary {
+   margin: 0;
+   color: #333;
+   /* good contrast on white */
+}
+
+/* Focus visibility for keyboard users (AA-friendly) */
+.card:focus-within,
+.card__link:focus-visible {
+   outline: 2px solid currentColor;
+   outline-offset: 3px;
+}
+
+/* Optional affordance */
+.card__link:hover {
+   text-decoration: underline;
+}
+
+/* Progressive enhancement for wider viewports */
+@media (min-width: 40rem) {
+
+   /* ~640px */
+   .cards {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+   }
+}
+
+@media (min-width: 64rem) {
+
+   /* ~1024px */
+   .cards {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+   }
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -33,6 +33,8 @@
 
 /* 5) SECTIONS (page-level rules) */
 @use "sections/home";
+@use "sections/about";
+@use "sections/projects";
 
 /* 6) UTILITIES (helpers & a11y utilities) */
 @use "utilities/visually-hidden";

--- a/src/scss/sections/_about.scss
+++ b/src/scss/sections/_about.scss
@@ -1,0 +1,48 @@
+/* sections/_about.scss
+   About page styles (mobile-first, no motion).
+   - Comfortable vertical spacing
+   - Readable measure for bio paragraphs
+   - Portrait scales down fluidly while honoring intrinsic dimensions
+*/
+
+.about {
+  padding-block: 1.5rem;
+  /* top/bottom */
+}
+
+.about p {
+  max-width: 65ch;
+  /* readable line length */
+  margin: 0;
+  /* let container spacing control rhythm */
+}
+
+.about__figure {
+  margin: 0 0 1rem 0;
+  /* space below image on small screens */
+  max-width: 16rem;
+  /* keep portraits modest on mobile */
+}
+
+.about__figure img {
+  display: block;
+  max-width: 100%;
+  /* fluid downscale, never overflow */
+  height: auto;
+  /* preserve aspect ratio (honors width/height attrs) */
+  border-radius: 0.5rem;
+}
+
+/* Slightly roomier on wider screens, no layout shifts */
+@media (min-width: 48rem) {
+
+  /* ~768px */
+  .about {
+    padding-block: 2rem;
+  }
+
+  .about__figure {
+    margin-bottom: 1.25rem;
+    max-width: 20rem;
+  }
+}

--- a/src/scss/sections/_home.scss
+++ b/src/scss/sections/_home.scss
@@ -1,4 +1,30 @@
 /* sections/_home.scss
-   Page/section-level styles used on Home (hero, featured projects, etc.).
-   Detailed rules later; placeholder for now.
+   Page-level styles for Home sections (hero, projects, contact).
+   Mobile-first spacings; no animations.
 */
+
+.hero {
+   padding-block: 2rem;
+   /* top & bottom */
+}
+
+.hero__tagline {
+   max-width: 65ch;
+}
+
+.home-section {
+   padding-block: 1.5rem;
+}
+
+/* Slightly roomier on larger screens */
+@media (min-width: 48rem) {
+
+   /* ~768px */
+   .hero {
+      padding-block: 3rem;
+   }
+
+   .home-section {
+      padding-block: 2rem;
+   }
+}

--- a/src/scss/sections/_projects.scss
+++ b/src/scss/sections/_projects.scss
@@ -1,0 +1,15 @@
+/* sections/_projects.scss
+   Projects index page styles (mobile-first).
+   Reuses .cards / .card from components.
+*/
+
+.projects {
+  padding-block: 1.5rem;
+}
+
+/* Optional: give the list a touch more breathing room on larger screens */
+@media (min-width: 48rem) {
+  .projects {
+    padding-block: 2rem;
+  }
+}

--- a/src/scss/utilities/_helpers.scss
+++ b/src/scss/utilities/_helpers.scss
@@ -1,4 +1,20 @@
 /* utilities/_helpers.scss
-   Small single-purpose helpers (e.g., .stack, .flow, text utilities).
-   Will be filled as needed later.
+   Small, single-purpose helpers.
+   - .stack: vertical rhythm utility (mobile-first)
+   - Future: add tiny alignment/text helpers if/when needed.
 */
+
+/* Vertical spacing between siblings
+   Usage: add `class="stack"` to a container. Optionally tune spacing via:
+   .stack { --stack-space: 1.25rem; }
+   MDN custom properties: https://developer.mozilla.org/en-US/docs/Web/CSS/--*
+*/
+.stack {
+   --stack-space: 1rem;
+   /* default gap */
+   display: block;
+}
+
+.stack>*+* {
+   margin-top: var(--stack-space);
+}

--- a/src/scss/utilities/_visually-hidden.scss
+++ b/src/scss/utilities/_visually-hidden.scss
@@ -1,8 +1,12 @@
-/* utilities/_visually-hidden.scss
-   A standard “visually hidden but screen-reader accessible” helper.
-   MDN discussion: https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Attributes/aria-hidden#hiding_content_visually
+/* src/scss/utilities/_visually-hidden.scss
+   Accessible helpers: visually-hidden + skip-link pattern.
+   - .sr-only / .visually-hidden: hide content visually but keep it for screen readers.
+   - .skip-link: off-screen until focused, then revealed with a clear outline.
 */
-.visually-hidden {
+
+.visually-hidden,
+.sr-only {
+  /* Classic "screen-reader only" utility */
   position: absolute !important;
   width: 1px !important;
   height: 1px !important;
@@ -13,4 +17,44 @@
   clip-path: inset(50%) !important;
   white-space: nowrap !important;
   border: 0 !important;
+}
+
+/* Keyboard-accessible "Skip to content" link */
+.skip-link {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+
+  /* Hidden by default (not display:none so it can still be focused) */
+  transform: translateY(-200%);
+  transition: transform 0.12s ease-in-out;
+
+  /* Legible, high-contrast default styling */
+  background: #fff;
+  color: #000;
+  border: 2px solid currentColor;
+  border-radius: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  font: inherit;
+  line-height: 1;
+  text-decoration: none;
+  z-index: 1000;
+
+  /* Reveal on focus */
+  &:focus,
+  &:focus-visible {
+    transform: translateY(0);
+    outline: none;
+    /* we already show a strong border */
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}
+
+/* Optional: ensure links show a visible style even if :focus-visible is not supported */
+:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
 }

--- a/src/templates/404.hbs
+++ b/src/templates/404.hbs
@@ -1,0 +1,20 @@
+{{!-- src/templates/404.hbs --}}
+{{!-- Custom 404 page
+- Compiles to dist/404.html (build.mjs compiles all root templates)
+- Links use {{prefixBase}} so it works on GitHub Pages project sites
+--}}
+{{#> layouts/base page=(hash title="Page not found" description="We couldn't find that page." path="/404.html")}}
+
+<section class="not-found stack" aria-labelledby="nf-title">
+  <h1 id="nf-title">Page not found</h1>
+  <p>Sorry, we can't find the page you're looking for. Try one of these:</p>
+
+  <ul class="stack" style="--stack-space:0.5rem;">
+    <li><a href="{{prefixBase '/' site.base}}">Home</a></li>
+    <li><a href="{{prefixBase '/projects.html' site.base}}">Projects</a></li>
+    <li><a href="{{prefixBase '/about.html' site.base}}">About</a></li>
+    <li><a href="{{prefixBase '#contact' site.base}}">Contact</a></li>
+  </ul>
+</section>
+
+{{/layouts/base}}

--- a/src/templates/about.hbs
+++ b/src/templates/about.hbs
@@ -1,0 +1,27 @@
+{{!-- src/templates/about.hbs --}}
+{{!-- About page: single H1, optional portrait, bio paragraphs --}}
+{{#> layouts/base page=(hash title="About" description=site.description path="/about.html")}}
+<section class="about stack" aria-labelledby="about-title">
+  <h1 id="about-title">About</h1>
+
+  {{!-- Optional portrait with explicit dimensions to avoid CLS --}}
+  {{#if site.about}}
+  {{#if site.about.portrait.src}}
+  <figure class="about__figure">
+    <img src="{{prefixBase site.about.portrait.src site.base}}" width="{{site.about.portrait.width}}"
+      height="{{site.about.portrait.height}}" alt="{{site.about.portrait.alt}}">
+  </figure>
+  {{/if}}
+
+  {{#if site.about.bio}}
+  {{#each site.about.bio}}
+  <p>{{this}}</p>
+  {{/each}}
+  {{else}}
+  <p>Bio coming soon.</p>
+  {{/if}}
+  {{else}}
+  <p>Bio coming soon.</p>
+  {{/if}}
+</section>
+{{/layouts/base}}

--- a/src/templates/index.hbs
+++ b/src/templates/index.hbs
@@ -1,19 +1,71 @@
-{{!-- src/templates/index.hbs --}}
-{{#> layouts/base page=(hash title="Home" description="Hello pipeline." path="/")}}
-<section class="stack">
-  <h1>{{site.title}}</h1>
-  <p>{{site.description}}</p>
+{{#> layouts/base page=(hash title="Home" description=site.description path="/")}}
+
+{{!--
+=========================
+Hero
+=========================
+--}}
+
+<section class="hero stack" aria-labelledby="home-title">
+  <h1 id="home-title">{{site.title}}</h1>
+  <p class="hero__tagline">
+    {{#if site.tagline}}{{site.tagline}}{{else}}{{site.description}}{{/if}}
+  </p>
 </section>
 
-{{!-- Projects anchor so the nav "Projects" (#projects) has a target --}}
-<section id="projects" class="stack">
-  <h2>Projects</h2>
+{{!--
+=========================
+Featured Projects
+- Graceful if data missing/empty (no orphan section content)
+=========================
+--}}
+
+<section id="projects" class="home-section stack" aria-labelledby="projects-title">
+  <h2 id="projects-title">Projects</h2>
+
+  {{#if site.projects}}
+  {{#if site.projects.length}}
+  <ul class="cards">
+    {{#each site.projects}}
+    {{#if this.featured}}
+    <li class="card">
+      {{#if this.url}}
+      <a class="card__link" href="{{prefixBase this.url ../../site.base}}">
+        <h3 class="card__title">{{this.title}}</h3>
+        {{#if this.summary}}<p class="card__summary">{{this.summary}}</p>{{/if}}
+      </a>
+      {{else}}
+      <div class="card__body">
+        <h3 class="card__title">{{this.title}}</h3>
+        {{#if this.summary}}<p class="card__summary">{{this.summary}}</p>{{/if}}
+      </div>
+      {{/if}}
+    </li>
+    {{/if}}
+    {{/each}}
+  </ul>
+  {{else}}
   <p>Coming soon.</p>
+  {{/if}}
+  {{else}}
+  <p>Coming soon.</p>
+  {{/if}}
 </section>
 
-{{!-- Contact anchor so the nav "Contact" (#contact) has a target --}}
-<section id="contact" class="stack">
-  <h2>Contact</h2>
-  <p>Drop a note via <a href="https://github.com/jaygtel">GitHub</a>.</p>
+{{!--
+=========================
+Contact call-to-action
+=========================
+--}}
+
+<section id="contact" class="home-section stack" aria-labelledby="contact-title">
+  <h2 id="contact-title">Contact</h2>
+  <p class="contact__blurb">Want to say hi or share an idea?</p>
+  <p>
+    {{!-- Placeholder CTA for now; proper form/page comes later (#11/#forms).
+    Use external link to GitHub profile as in baseline. --}}
+    <a class="button" href="https://github.com/jaygtel" rel="noopener">Message me on GitHub</a>
+  </p>
 </section>
+
 {{/layouts/base}}

--- a/src/templates/layouts/base.hbs
+++ b/src/templates/layouts/base.hbs
@@ -8,7 +8,7 @@
 </head>
 
 <body>
-  <a class="skip-link" href="#main">Skip to content</a>
+  {{> skiplink}} {{!-- ⟵ FIRST focusable element for keyboard users --}}
 
   {{> header site=site}}
 

--- a/src/templates/partials/skiplink.hbs
+++ b/src/templates/partials/skiplink.hbs
@@ -1,0 +1,1 @@
+<a class="skip-link" href="#main">Skip to content</a>

--- a/src/templates/projects.hbs
+++ b/src/templates/projects.hbs
@@ -1,0 +1,33 @@
+{{!-- src/templates/projects.hbs --}}
+{{!-- Projects index: single H1, list of cards if data exists --}}
+{{#> layouts/base page=(hash title="Projects" description=site.description path="/projects.html")}}
+<section class="projects stack" aria-labelledby="projects-title">
+  <h1 id="projects-title">Projects</h1>
+
+  {{#if site.projects}}
+  {{#if site.projects.length}}
+  <ul class="cards">
+    {{#each site.projects}}
+    <li class="card">
+      {{#if this.url}}
+      <a class="card__link" href="{{prefixBase this.url ../../site.base}}">
+        <h2 class="card__title">{{this.title}}</h2>
+        {{#if this.summary}}<p class="card__summary">{{this.summary}}</p>{{/if}}
+      </a>
+      {{else}}
+      <div class="card__body">
+        <h2 class="card__title">{{this.title}}</h2>
+        {{#if this.summary}}<p class="card__summary">{{this.summary}}</p>{{/if}}
+      </div>
+      {{/if}}
+    </li>
+    {{/each}}
+  </ul>
+  {{else}}
+  <p>No projects yet.</p>
+  {{/if}}
+  {{else}}
+  <p>No projects yet.</p>
+  {{/if}}
+</section>
+{{/layouts/base}}


### PR DESCRIPTION
## Summary
Milestone M03 delivers the core semantic pages and baseline mobile-first styling:
- Home: single H1 hero, featured projects fallback, contact CTA
- About: bio + optional portrait (CLS-safe via width/height)
- Projects: cards grid ready; graceful empty state
- 404: custom page at root with Pages-safe links
- A11Y: visible “Skip to content” link; focusable <main>

## Changes
- NEW: src/templates/404.hbs
- NEW: src/templates/about.hbs
- NEW: src/templates/projects.hbs
- UPDATE: src/templates/index.hbs (Home structure)
- UPDATE: src/data/site.json (nav to real pages, about.bio/portrait, empty projects)
- UPDATE: SCSS (mobile-first):
  - sections/_home.scss, sections/_about.scss, sections/_projects.scss
  - components/_cards.scss, components/_buttons.scss
  - utilities/_helpers.scss (.stack)
  - main.scss wired to sections
- Docs only (no code): docs/deferred/98-pr-build-automerge.md

## How to Test
1) Build locally: `npm run build` → open `dist/`
2) Pages-safe links: Home/Projects/About/404 should resolve correctly when deployed under the project path
3) Keyboard: Tab → “Skip to content”; Enter → focus lands on `<main id="main" tabindex="-1">`
4) One `<h1>` per page; headings and landmarks are semantic

## References (do not close)
Ref #98 (deferred; no code changes shipped)

## Closes
Closes #10
Closes #11
Closes #12
Closes #99

